### PR TITLE
Added devserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,26 @@ USER datapunt
 
 CMD ["/deploy/docker-run.sh"]
 
-# stage 2, tests
-FROM app as tests
+# devserver
+FROM app as dev
 
 USER root
 WORKDIR /app_install
 ADD requirements_dev.txt requirements_dev.txt
 RUN pip install -r requirements_dev.txt
 RUN chmod -R a+r /app_install
+
+WORKDIR /src
+USER datapunt
+
+# Any process that requires to write in the home dir
+# we write to /tmp since we have no home dir
+ENV HOME /tmp
+
+CMD ["python manage.py runserver 0.0.0.0"]
+
+# tests
+FROM dev as tests
 
 USER datapunt
 WORKDIR /tests

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ push:
 app:
 	$(dc) run --service-ports app
 
+dev:
+	$(dc) run --service-ports dev
+
 test:
 	$(dc) run --rm test pytest $(ARGS)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,24 @@ services:
     entrypoint: /deploy/wait-for-it.sh database:5432 --
     command: python manage.py runserver 0.0.0.0:8000
 
+  dev:
+    build:
+      context: .
+      target: dev
+    ports:
+      - 8000:8000
+    environment:
+      DEBUG: "true"
+      SECRET_KEY: "dev"
+      PYTHONBREAKPOINT:
+    volumes:
+      - ./src:/src
+      - ./deploy:/deploy
+    depends_on:
+      - database
+    entrypoint: /deploy/wait-for-it.sh database:5432 --
+    command: python manage.py runserver 0.0.0.0:8000
+
   test:
     build:
       context: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.2.3            # via django
 certifi==2019.11.28       # via sentry-sdk
-django-extensions==2.2.7
+django-extensions==2.2.8
 django==3.0.3
 djangorestframework==3.11.0
 psycopg2==2.8.4

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -16,3 +16,5 @@ pytest-django
 pytest-cov
 pytest-factoryboy
 ipython
+ipdb
+jedi

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ certifi==2019.11.28
 click==7.0                # via pip-tools
 coverage==5.0.3           # via pytest-cov
 decorator==4.4.1          # via ipython, traitlets
-django-extensions==2.2.7
+django-extensions==2.2.8
 django==3.0.3
 djangorestframework==3.11.0
 entrypoints==0.3          # via flake8
@@ -19,10 +19,11 @@ factory-boy==2.12.0       # via pytest-factoryboy
 faker==4.0.0              # via factory-boy
 flake8==3.7.9
 inflection==0.3.1         # via pytest-factoryboy
+ipdb==0.12.3
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.12.0
 isort==4.3.21
-jedi==0.16.0              # via ipython
+jedi==0.16.0
 mccabe==0.6.1             # via flake8
 more-itertools==8.2.0     # via pytest
 packaging==20.1           # via pytest


### PR DESCRIPTION
Dev server has requirements_Dev dependencies installed to help development / debugging
`make dev` will run the server

To use ipdb for example you can use `PYTHONBREAKPOINT=ipdb.set_trace make dev`