### PR TITLE
Voeg docker-compose.override.yml aan .gitignore toe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ coverage.xml
 
 # SQLite databse files
 *.sqlite3
+
+# docker-compose
+docker-compose.override.yml


### PR DESCRIPTION
Zorgt ervoor dat je afwijkende docker-compose settings kan hebben, zonder dat ze aan git toegevoegd worden.